### PR TITLE
Upgrade the api to 4.6 snapshot version, for admin api development.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <grpc.version>1.36.0</grpc.version>
-        <axonserver.api.version>4.5</axonserver.api.version>
+        <axonserver.api.version>4.6.0-SNAPSHOT</axonserver.api.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This should not be needed. 
It would be useful to find a better mechanism to synchronize the axonserver-api version between AS-SE, AS-EE and axon-server-plugin-api. 
(Please note that as-se pom contains a property to define `axonserver.api.version`, that is actually unused.)